### PR TITLE
fix: add missing dependency to tools

### DIFF
--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -19,6 +19,7 @@
   },
   "type": "module",
   "dependencies": {
+    "axios": "^1.7.9",
     "fabrice-ai": "0.1.2",
     "zod": "^3.23.8"
   },


### PR DESCRIPTION
Missing after recent move to tools