### PR TITLE
feat: collect token usage

### DIFF
--- a/packages/framework/src/supervisor/finalizeWorkflow.ts
+++ b/packages/framework/src/supervisor/finalizeWorkflow.ts
@@ -3,9 +3,14 @@ import { zodResponseFormat } from 'openai/helpers/zod'
 import { z } from 'zod'
 
 import { Provider } from '../models.js'
-import { Message } from '../types.js'
+import { Message, Usage } from '../types.js'
 
-export async function finalizeWorkflow(provider: Provider, messages: Message[]): Promise<string> {
+export type FinalizeWorkflowResult = {
+  response: string
+  usage?: Usage
+}
+
+export async function finalizeWorkflow(provider: Provider, messages: Message[]): Promise<FinalizeWorkflowResult> {
   const response = await provider.completions({
     messages: [
       {
@@ -29,5 +34,9 @@ export async function finalizeWorkflow(provider: Provider, messages: Message[]):
   if (!result) {
     throw new Error('No parsed response received')
   }
-  return result.finalAnswer
+
+  return {
+    response: result.finalAnswer,
+    usage: response.usage,
+  };
 }

--- a/packages/framework/src/supervisor/nextTask.ts
+++ b/packages/framework/src/supervisor/nextTask.ts
@@ -3,9 +3,14 @@ import { zodResponseFormat } from 'openai/helpers/zod'
 import { z } from 'zod'
 
 import { Provider } from '../models.js'
-import { Message } from '../types.js'
+import { Message, Usage } from '../types.js'
 
-export async function nextTask(provider: Provider, history: Message[]): Promise<string | null> {
+export type NextTaskResult = {
+  task: string | null
+  usage?: Usage
+}
+
+export async function nextTask(provider: Provider, history: Message[]): Promise<NextTaskResult> {
   const response = await provider.completions({
     messages: [
       {
@@ -53,10 +58,10 @@ export async function nextTask(provider: Provider, history: Message[]): Promise<
     }
 
     if (!content.task) {
-      return null
+      return { task: null, usage: response.usage }
     }
 
-    return content.task
+    return { task: content.task, usage: response.usage }
   } catch (error) {
     throw new Error('Failed to determine next task')
   }

--- a/packages/framework/src/supervisor/selectAgent.ts
+++ b/packages/framework/src/supervisor/selectAgent.ts
@@ -4,13 +4,18 @@ import { z } from 'zod'
 
 import { Agent } from '../agent.js'
 import { Provider } from '../models.js'
-import { Message } from '../types.js'
+import { Message, Usage } from '../types.js'
+
+export type SelectAgentResult = {
+  agent: Agent
+  usage?: Usage
+}
 
 export async function selectAgent(
   provider: Provider,
   agentRequest: Message[],
   agents: Agent[]
-): Promise<Agent> {
+): Promise<SelectAgentResult> {
   const response = await provider.completions({
     messages: [
       {
@@ -64,5 +69,5 @@ export async function selectAgent(
     throw new Error('Invalid agent')
   }
 
-  return agent
+  return { agent, usage: response.usage }
 }

--- a/packages/framework/src/telemetry.ts
+++ b/packages/framework/src/telemetry.ts
@@ -66,9 +66,12 @@ export const logger: Telemetry = ({ prevState, nextState }) => {
         break
       case 'finished':
         logMessage(
-          '🎉',
-          'Workflow finished successfully!',
-          `Total messages: ${nextState.messages.length}`
+          "🎉",
+          "Workflow finished successfully!",
+          [ 
+            `Total messages: ${nextState.messages.length}`,
+            `Total tokens: ${nextState.usage.total_tokens} (input: ${nextState.usage.prompt_tokens}, output: ${nextState.usage.completion_tokens})`,
+          ].join('\n')
         )
         break
       case 'failed':

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -1,4 +1,5 @@
 import type { ChatCompletionMessageParam } from 'openai/resources/chat/completions'
+import type { CompletionUsage } from 'openai/resources/completions.mjs'
 
 /**
  * Utility type to get optional keys from T.
@@ -22,3 +23,8 @@ export type RequiredOptionals<T> = Required<OptionalProperties<T>>
  */
 export type Message = ChatCompletionMessageParam
 export type MessageContent = Message['content']
+
+/**
+ * Usage type for completion
+ */
+export type Usage = CompletionUsage;

--- a/packages/framework/src/workflow.ts
+++ b/packages/framework/src/workflow.ts
@@ -5,7 +5,7 @@ import s from 'dedent'
 import { Agent } from './agent.js'
 import { openai, Provider } from './models.js'
 import { noop, Telemetry } from './telemetry.js'
-import { Message } from './types.js'
+import { Message, Usage } from './types.js'
 
 type WorkflowOptions = {
   description: string
@@ -35,9 +35,10 @@ export type Workflow = Required<WorkflowOptions>
  * Base workflow
  */
 type BaseWorkflowState = {
-  id: string
-  messages: Message[]
-}
+  id: string;
+  messages: Message[];
+  usage: Usage;
+};
 
 /**
  * Different states workflow is in, in between execution from agents
@@ -47,7 +48,7 @@ export type IdleWorkflowState = BaseWorkflowState & {
 }
 
 /**
- * Supervisor selected the task, and is now pending assignement of an agent
+ * Supervisor selected the task, and is now pending assignment of an agent
  */
 export type PendingWorkflowState = BaseWorkflowState & {
   status: 'pending'
@@ -84,6 +85,11 @@ export const workflowState = (workflow: Workflow): IdleWorkflowState => {
         `,
       },
     ],
+    usage: {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    },
   }
 }
 

--- a/packages/tools/src/vision.ts
+++ b/packages/tools/src/vision.ts
@@ -4,12 +4,18 @@ import path from 'node:path'
 import s from 'dedent'
 import { Provider } from 'fabrice-ai/models'
 import { tool } from 'fabrice-ai/tool'
+import { CompletionUsage } from 'openai/resources/completions.mjs'
 import { zodResponseFormat } from 'openai/helpers/zod'
 import { z } from 'zod'
 
 const encodeImage = async (imagePath: string): Promise<string> => {
   const imageBuffer = await fs.readFile(imagePath)
   return `data:image/${path.extname(imagePath).toLowerCase().replace('.', '')};base64,${imageBuffer.toString('base64')}`
+}
+
+export type CallOpenAIResult = {
+  text: string
+  usage?: CompletionUsage
 }
 
 async function callOpenAI(


### PR DESCRIPTION
## Summary

Collect token usage during all types of LLMs requests.

<img width="529" alt="image" src="https://github.com/user-attachments/assets/74f8559d-5f24-45e2-84a5-7915a2465b7a">


## Details

1. Added `usage` field to `BaseWorkflowState` type, of the `CompletionUsage` type imported from OpenAI SDK.
2. Modified all LLMs calls to also return usage stats

## Alternatively
Alternatively instead of having a separate accumulator variable on state, it could be calculated from messeges if there were to hold it as well. There would also be a need to capture the orchestration usage (e.g. `selectAgent`) as these are not directly reflected in the messages.

## Test plan
Tested manually on `surprise_trip.ts` example

Resolves #8 