### PR TITLE
fix: missing @clack/prompts dep in tools

### DIFF
--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -19,6 +19,7 @@
   },
   "type": "module",
   "dependencies": {
+    "@clack/prompts": "^0.8.2",
     "axios": "^1.7.9",
     "fabrice-ai": "0.4.3",
     "zod": "^3.23.8"


### PR DESCRIPTION
## Summary 

Add missing `@clack/prompts` dep in tools:

When running `github_trending` template I got following error:

Error details:
```
fabrice-test-3 % bun src/github_trending.ts
error: Cannot find module "@clack/prompts" from "/Users/maciej/Development/Other/fabrice-test-3/node_modules/@fabrice-ai/tools/src/utils.ts"
```

