### PR TITLE
fix: __dirname should not be used in ES Module

### DIFF
--- a/example/src/ecommerce_product_description.ts
+++ b/example/src/ecommerce_product_description.ts
@@ -3,6 +3,7 @@ import { agent } from 'fabrice-ai/agent'
 import { teamwork } from 'fabrice-ai/teamwork'
 import { logger } from 'fabrice-ai/telemetry'
 import { solution, workflow } from 'fabrice-ai/workflow'
+import path from 'path'
 
 const techExpert = agent({
   role: 'Technical expert',
@@ -27,7 +28,7 @@ const marketingManager = agent({
 const productDescriptionWorkflow = workflow({
   members: [techExpert, marketingManager],
   description: `
-    Based on the picture './example/assets/example-sneakers.jpg' make the eCommerce product to 
+    Based on the picture '${path.resolve(__dirname, '../assets/example-sneakers.jpg')}' make the eCommerce product to 
     list this product on the website.
 
     Focus:
@@ -44,7 +45,6 @@ const productDescriptionWorkflow = workflow({
   `,
   snapshot: logger,
 })
-
 const result = await teamwork(productDescriptionWorkflow)
 
 console.log(solution(result))

--- a/example/src/ecommerce_product_description.ts
+++ b/example/src/ecommerce_product_description.ts
@@ -28,7 +28,7 @@ const marketingManager = agent({
 const productDescriptionWorkflow = workflow({
   members: [techExpert, marketingManager],
   description: `
-    Based on the picture '${path.resolve(__dirname, '../assets/example-sneakers.jpg')}' make the eCommerce product to 
+    Based on the picture '${path.resolve(import.meta.dirname, '../assets/example-sneakers.jpg')}' make the eCommerce product to 
     list this product on the website.
 
     Focus:

--- a/example/src/library_photo_to_website.ts
+++ b/example/src/library_photo_to_website.ts
@@ -6,7 +6,7 @@ import { logger } from 'fabrice-ai/telemetry'
 import { solution, workflow } from 'fabrice-ai/workflow'
 import path from 'path'
 
-const workingDir = path.resolve(__dirname, '../assets/')
+const workingDir = path.resolve(import.meta.dirname, '../assets/')
 
 const { saveFile, readFile, listFilesFromDirectory } = createFileSystemTools({
   workingDir,

--- a/packages/create-fabrice-ai/src/utils.ts
+++ b/packages/create-fabrice-ai/src/utils.ts
@@ -1,12 +1,7 @@
 import { execSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
-import { dirname } from 'node:path'
 import { promises as Stream, Readable } from 'node:stream'
-import { fileURLToPath } from 'node:url'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
 
 import { extract } from 'tar'
 
@@ -58,6 +53,6 @@ export async function copyAdditionalTemplateFiles(root: string) {
   ]
 
   for (const file of files) {
-    execSync(`cp ${path.join(__dirname, file.src)} ${path.join(root, file.dest)}`)
+    execSync(`cp ${path.join(import.meta.dirname, file.src)} ${path.join(root, file.dest)}`)
   }
 }

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -173,7 +173,7 @@ File system tools for reading, writing and listing files. The tools are sandboxe
 ```typescript
 import { createFileSystemTools } from '@fabrice-ai/tools/filesystem'
 
-const workingDir = path.resolve(__dirname, '../assets/')
+const workingDir = path.resolve(import.meta.dirname, '../assets/')
 
 const { saveFile, readFile, listFilesFromDirectory } = createFileSystemTools({
   workingDir,


### PR DESCRIPTION
... instead of a relative image path (which didn't work with
`create-fabrice-ai` cloned example)