### PR TITLE
fix: final fixes on github_trending_vector - simplifying the workflow…

### DIFF
--- a/example/src/github_trending_vector.ts
+++ b/example/src/github_trending_vector.ts
@@ -5,9 +5,7 @@ import { agent } from 'fabrice-ai/agent'
 import { solution } from 'fabrice-ai/solution'
 import { teamwork } from 'fabrice-ai/teamwork'
 import { logger } from 'fabrice-ai/telemetry'
-import { tool } from 'fabrice-ai/tool'
 import { workflow } from 'fabrice-ai/workflow'
-import { z } from 'zod'
 
 import { askUser } from './tools/askUser.js'
 
@@ -19,11 +17,10 @@ const { firecrawl } = createFireCrawlTool({
   apiKey,
 })
 
-const githubResearcher = agent({
+const webCrawler = agent({
   description: `
-    You are skilled at browsing Github pages.
+    You are skilled at browsing Web pages.
     You are saving the documents to vector store for later usage.
-    You don't do any other thing just these two tasks.
   `,
   tools: {
     firecrawl,
@@ -31,34 +28,43 @@ const githubResearcher = agent({
   },
 })
 
-const wrapupRedactor = agent({
+const topicSelector = agent({
+  description: `
+    You ask users for the topic specified in the task.
+  `,
+  tools: {
+    askUser,
+  },
+})
+
+const reportCompiler = agent({
   description: `
     You ask users for which topic to focus on if it's defined in the task.
     Then - you search relevant information in Vector Store and compile reports based on it.
     You're famous of beautiful Markdown formatting.
   `,
   tools: {
-    askUser,
     searchInVectorStore,
   },
 })
 
 const wrapUpTrending = workflow({
-  team: { githubResearcher, wrapupRedactor },
+  team: { webCrawler, topicSelector, reportCompiler },
   description: `
-    Research the URL "https://github.com/trending/typescript" page using firecrawl tool
-    Select 3 top projects. Browse for details about these projects on their subpages. 
-    Save it all to the vector store.
+    Research the URL "https://github.com/trending/typescript" page.
+    Select 3 top projects. Browse details about these projects on their subpages.
+    Store each page in Vector Store for further usage.
+    After you store the information you don't need to browse the page again 
+    because everything is stored in Vector Store.
 
-    Ask user about which project he wants to learn more.
-    reate a comprehensive report markdown output:
+    Ask user about which project he wants to learn more. Ask user only once.
+
+    Create a comprehensive markdown report using information from Vector Store, based on user selection:
      - create a one, two sentence summary about every project.
      - include detailed summary about the project selected by the user.
 
     Here are some ground rules to follow: 
-      - Browser the pages onle once and store content in Vector Store. 
       - Use Vector Store if you need information about the project.
-      - Before making up the record: ask user about which project he wants to learn more.
   `,
   output: `
     Comprehensive markdown report including:

--- a/example/src/github_trending_vector.ts
+++ b/example/src/github_trending_vector.ts
@@ -28,9 +28,9 @@ const webCrawler = agent({
   },
 })
 
-const topicSelector = agent({
+const human = agent({
   description: `
-    You ask users for the topic specified in the task.
+    You can ask user and get their answer to questions that are needed by other agents.
   `,
   tools: {
     askUser,
@@ -39,8 +39,8 @@ const topicSelector = agent({
 
 const reportCompiler = agent({
   description: `
-    You ask users for which topic to focus on if it's defined in the task.
-    Then - you search relevant information in Vector Store and compile reports based on it.
+    You can search Vector Store to find relevant informations and create reports based on it
+    Based on the information from Vector Store you can compile a comprehensive report.
     You're famous of beautiful Markdown formatting.
   `,
   tools: {
@@ -49,7 +49,7 @@ const reportCompiler = agent({
 })
 
 const wrapUpTrending = workflow({
-  team: { webCrawler, topicSelector, reportCompiler },
+  team: { webCrawler, human, reportCompiler },
   description: `
     Research the URL "https://github.com/trending/typescript" page.
     Select 3 top projects. Browse details about these projects on their subpages.


### PR DESCRIPTION
… + dividing it into more self-explanatory agent roles for making `resourcePlanner` life easier

I need your help @grabbou. After streamlining the workflow, everything goes very well until the step of asking the user about which project he/she wants to get details on:

![image](https://github.com/user-attachments/assets/3bf1d98c-268f-460a-acca-0f21b2bdae66)

It looks like asking the question is a step of browsing pages - which is a supervisor's bad decision. There's a special agent `topicSelector` just for that. I haven't yet found out why this happened. Any ideas?