### PR TITLE
feat(create-fabrice-ai): downloading latest release

### DIFF
--- a/packages/create-fabrice-ai/src/index.ts
+++ b/packages/create-fabrice-ai/src/index.ts
@@ -12,8 +12,8 @@ import {
   copyAdditionalTemplateFiles,
   downloadAndExtractTemplate,
   formatTargetDir,
-  getLatestReleaseInfo,
   isNodeError,
+  latestReleaseDownloadLink,
 } from './utils.js'
 
 console.log(
@@ -134,11 +134,11 @@ if (typeof template !== 'object') {
 
 const s = spinner()
 
-const lastReleaseInfo = await getLatestReleaseInfo('callstackincubator', 'fabrice-ai')
+const releaseTarballUrl = await latestReleaseDownloadLink('callstackincubator', 'fabrice-ai')
 
-s.start(`Downloading template (${lastReleaseInfo.tag_name})...`)
+s.start(`Downloading template...`)
 
-await downloadAndExtractTemplate(root, lastReleaseInfo.tarball_url, template.files)
+await downloadAndExtractTemplate(root, releaseTarballUrl, template.files)
 
 copyAdditionalTemplateFiles(root)
 

--- a/packages/create-fabrice-ai/src/index.ts
+++ b/packages/create-fabrice-ai/src/index.ts
@@ -12,6 +12,7 @@ import {
   copyAdditionalTemplateFiles,
   downloadAndExtractTemplate,
   formatTargetDir,
+  getLatestReleaseInfo,
   isNodeError,
 } from './utils.js'
 
@@ -133,13 +134,11 @@ if (typeof template !== 'object') {
 
 const s = spinner()
 
-s.start('Downloading template...')
+const lastReleaseInfo = await getLatestReleaseInfo('callstackincubator', 'fabrice-ai')
 
-await downloadAndExtractTemplate(
-  root,
-  'https://github.com/callstackincubator/fabrice-ai/archive/refs/heads/main.tar.gz',
-  template.files
-)
+s.start(`Downloading template (${lastReleaseInfo.tag_name})...`)
+
+await downloadAndExtractTemplate(root, lastReleaseInfo.tarball_url, template.files)
 
 copyAdditionalTemplateFiles(root)
 

--- a/packages/create-fabrice-ai/src/utils.ts
+++ b/packages/create-fabrice-ai/src/utils.ts
@@ -16,15 +16,16 @@ export async function latestReleaseDownloadLink(
   const response = await fetch(
     `https://api.github.com/repos/${organization}/${repo}/releases/latest`
   )
-  
+
   if (!response.ok) {
     throw new Error(`Failed to fetch release info from ${response.url}.`)
   }
-  
+
   const body = await response.json()
   if (!('tarball_url' in body) || typeof body.tarball_url !== 'string') {
-    throw new Error()
+    throw new Error(`Failed to get tarball url from ${response.url}.`)
   }
+
   return body.tarball_url
 }
 
@@ -38,7 +39,7 @@ export async function downloadAndExtractTemplate(root: string, tarball: string, 
     // @ts-ignore
     Readable.fromWeb(response.body),
     extract({
-      cwd: tmpdir(),
+      cwd: path.join(import.meta.dirname),
       strip: 1,
     }),
   ])

--- a/packages/create-fabrice-ai/src/utils.ts
+++ b/packages/create-fabrice-ai/src/utils.ts
@@ -9,52 +9,23 @@ export function formatTargetDir(targetDir: string) {
   return targetDir.trim().replace(/\/+$/g, '')
 }
 
-export interface GithubReleaseInfo {
-  url: string
-  assets_url: string
-  upload_url: string
-  html_url: string
-  id: number
-  author: {
-    login: string
-    id: number
-    avatar_url: string
-    gravatar_id: string
-    url: string
-    repos_url: string
-    events_url: string
-    type: string
-  }
-  node_id: string
-  tag_name: string
-  target_commitish: string
-  name: string
-  draft: boolean
-  prerelease: boolean
-  created_at: string
-  published_at: string
-  assets: any[]
-  tarball_url: string
-  zipball_url: string
-}
-
-export async function getLatestReleaseInfo(
+export async function latestReleaseDownloadLink(
   organization: string,
   repo: string
-): Promise<GithubReleaseInfo> {
+): Promise<string> {
   const response = await fetch(
     `https://api.github.com/repos/${organization}/${repo}/releases/latest`
   )
+  
   if (!response.ok) {
     throw new Error(`Failed to fetch release info from ${response.url}.`)
   }
-
-  return await response.json()
-}
-
-export async function latestReleaseDownloadLink(organization: string, repo: string) {
-  const latestRelease = await getLatestReleaseInfo(organization, repo)
-  return latestRelease.tarball_url
+  
+  const body = await response.json()
+  if (!('tarball_url' in body) || typeof body.tarball_url !== 'string') {
+    throw new Error()
+  }
+  return body.tarball_url
 }
 
 export async function downloadAndExtractTemplate(root: string, tarball: string, files: string[]) {


### PR DESCRIPTION
Before, we downloaded the `main` snapshot. It was fine. However, it didn't work well when the current `main` source code was incompatible with the released `npm` modules. This situation happened with the recent #105. Now, we're getting the latest official release and taking the examples out of it.

Because the tarball starts with a directory of an unknown name (in fact, it's the `org-repo-lastcommitid` kind of) - we're about to extract the full release and not only the example folder (as it was before) because the leading directory name is unknown. 