### PR TITLE
PoC: feat: ollama support - as for now it doesn't work due to Ollama i…

### DIFF
--- a/example/src/news_wrap_up_ollama.ts
+++ b/example/src/news_wrap_up_ollama.ts
@@ -4,18 +4,26 @@ import { getCurrentDate } from '@fabrice-ai/tools/date'
 import { getApiKey } from '@fabrice-ai/tools/utils'
 import { createWebSearchTools } from '@fabrice-ai/tools/webSearch'
 import { agent } from 'fabrice-ai/agent'
+import { openai } from 'fabrice-ai/models'
 import { solution } from 'fabrice-ai/solution'
 import { teamwork } from 'fabrice-ai/teamwork'
 import { logger } from 'fabrice-ai/telemetry'
 import { workflow } from 'fabrice-ai/workflow'
 
 const apiKey = await getApiKey('Serply.io API', 'SERPLY_API_KEY')
+const ollama = openai({
+  options: {
+    baseURL: 'http://localhost:11434/v1',
+  },
+  model: 'llama3.1',
+})
 
 const { googleSearch } = createWebSearchTools({
   apiKey,
 })
 
 const newsResearcher = agent({
+  provider: ollama,
   description: `
     You are skilled at searching the News over Web.
     Your job is to get the news from the last week.
@@ -27,6 +35,7 @@ const newsResearcher = agent({
 })
 
 const newsReader = agent({
+  provider: ollama,
   description: `
     You're greatly skilled at reading and summarizing news headlines.
     Other team members rely on you to get the gist of the news.
@@ -35,6 +44,7 @@ const newsReader = agent({
 })
 
 const wrapupRedactor = agent({
+  provider: ollama,
   description: `
     Your role is to wrap up the news and trends for the last week into a comprehensive report.
     Generalization is also one of your powerfull skills, however you're not a fortune teller.

--- a/example/src/surprise_trip_ollama.ts
+++ b/example/src/surprise_trip_ollama.ts
@@ -1,0 +1,90 @@
+import { agent } from 'fabrice-ai/agent'
+import { openai } from 'fabrice-ai/models'
+import { solution } from 'fabrice-ai/solution'
+import { teamwork } from 'fabrice-ai/teamwork'
+import { logger } from 'fabrice-ai/telemetry'
+import { workflow } from 'fabrice-ai/workflow'
+
+import { lookupWikipedia } from './tools/wikipedia.js'
+
+const ollama = openai({
+  options: {
+    baseURL: 'http://localhost:11434/v1',
+  },
+  model: 'llama3.1',
+})
+
+const personalizedActivityPlanner = agent({
+  provider: ollama,
+  description: `
+    You are skilled at creating personalized itineraries that cater to
+    the specific preferences and demographics of travelers.
+    Your goal is to research and find cool things to do at the destination,
+    including activities and events that match the traveler's interests and age group.
+  `,
+})
+
+const landmarkScout = agent({
+  provider: ollama,
+  description: `
+    You are skilled at researching and finding interesting landmarks at the destination.
+    Your goal is to find historical landmarks, museums, and other interesting places.
+  `,
+  tools: {
+    lookupWikipedia,
+  },
+})
+
+const restaurantScout = agent({
+  provider: ollama,
+  description: `
+    As a food lover, you know the best spots in town for a delightful culinary experience.
+    You also have a knack for finding picturesque and entertaining locations.
+    Your goal is to find highly-rated restaurants and dining experiences at the destination,
+    and recommend scenic locations and fun activities.
+  `,
+})
+
+const itineraryCompiler = agent({
+  provider: ollama,
+  description: `
+    With an eye for detail, you organize all the information into a coherent and enjoyable travel plan.
+    Your goal is to compile all researched information into a comprehensive day-by-day itinerary,
+    ensuring the integration of flights and hotel information.
+  `,
+})
+
+const researchTripWorkflow = workflow({
+  team: {
+    personalizedActivityPlanner,
+    restaurantScout,
+    landmarkScout,
+    itineraryCompiler,
+  },
+  description: `
+    Research and find cool things to do in Wrocław, Poland.
+
+    Focus:
+      - activities and events that match the traveler's interests and age group.
+      - highly-rated restaurants and dining experiences.
+      - landmarks with historic context.
+      - picturesque and entertaining locations.
+
+    Traveler's information:
+      - Origin: New York, USA
+      - Destination: Wrocław, Poland
+      - Age of the traveler: 30
+      - Hotel location: Main Square, Wrocław
+      - Flight information: Flight AA123, arriving on 2023-12-15
+      - How long is the trip: 7 days
+  `,
+  output: `
+    Comprehensive day-by-day itinerary for the trip to Wrocław, Poland.
+    Ensure the itinerary integrates flights, hotel information, and all planned activities and dining experiences.
+  `,
+  snapshot: logger,
+})
+
+const result = await teamwork(researchTripWorkflow)
+
+console.log(solution(result))

--- a/packages/framework/src/models.ts
+++ b/packages/framework/src/models.ts
@@ -1,7 +1,7 @@
 import OpenAI, { ClientOptions } from 'openai'
 import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/chat/completions'
 
-type OpenAIOptions = {
+export type OpenAIOptions = {
   model?: string
   options?: ClientOptions
 }


### PR DESCRIPTION
…gnoring `response_format` :/

This feature works on assumptions that Ollama offers a special, Open AI compatible API: https://ollama.com/blog/openai-compatibility

From what I researched it should support `response_format` and `tools` - https://github.com/ollama/ollama/blob/main/docs/openai.md

<img width="478" alt="image" src="https://github.com/user-attachments/assets/9556a29f-7671-4f11-ac3d-78891a1c9a5a" />

However, from my tests, it's being ignored - and the full text is returned  - tested on `llama3.1:latest` - `7B` parameters

Subject to further tests