### PR TITLE
refactor: remove `embeddings` interface

### DIFF
--- a/packages/framework/src/models.ts
+++ b/packages/framework/src/models.ts
@@ -62,10 +62,6 @@ export interface Provider {
     args: LLMCallWithTools<T>
   ): Promise<FunctionToolCall | LLMResponse<T>>
   chat<T extends LLMResponseFormat>(args: LLMCall<T>): Promise<LLMResponse<T>>
-  /**
-   * Method for generating embeddings.
-   */
-  embeddings(input: string): Promise<number[]>
 }
 
 /**

--- a/packages/framework/src/providers/grok.ts
+++ b/packages/framework/src/providers/grok.ts
@@ -19,10 +19,9 @@ type GrokOptions = Partial<OpenAIProviderOptions>
  * As of now, Grok doesn't support strict mode.
  */
 export const grok = (options: GrokOptions = {}): Provider => {
-  const { model = 'grok-beta', embeddingsModel = 'v1', options: clientOptions } = options
+  const { model = 'grok-beta', options: clientOptions } = options
   return openai({
     model,
-    embeddingsModel,
     strictMode: false,
     options: {
       apiKey: process.env.GROK_API_KEY,

--- a/packages/framework/src/providers/openai.ts
+++ b/packages/framework/src/providers/openai.ts
@@ -4,7 +4,6 @@ import { Provider, responseAsStructuredOutput, toLLMTools } from '../models.js'
 
 type OpenAIProviderOptions = {
   model?: string
-  embeddingsModel?: string
   options?: OpenAIOptions
 }
 
@@ -17,11 +16,7 @@ type OpenAIProviderOptions = {
  * otherwise you will get an error. Otherwise, use the one from `openai_response_functions.js` instead.
  */
 export const openai = (options: OpenAIProviderOptions = {}): Provider => {
-  const {
-    model = 'gpt-4o',
-    embeddingsModel = 'text-embedding-ada-002',
-    options: clientOptions,
-  } = options
+  const { model = 'gpt-4o', options: clientOptions } = options
   const client = new OpenAI(clientOptions)
 
   return {
@@ -50,13 +45,6 @@ export const openai = (options: OpenAIProviderOptions = {}): Provider => {
       }
 
       return message.parsed.response
-    },
-    embeddings: async (input: string) => {
-      const response = await client.embeddings.create({
-        model: embeddingsModel,
-        input,
-      })
-      return response.data[0].embedding
     },
   }
 }

--- a/packages/framework/src/providers/openai_response_functions.ts
+++ b/packages/framework/src/providers/openai_response_functions.ts
@@ -13,10 +13,6 @@ export type OpenAIProviderOptions = {
    */
   model: string
   /**
-   * Embeddings model to use.
-   */
-  embeddingsModel: string
-  /**
    * Client options.
    */
   options: ClientOptions
@@ -34,7 +30,7 @@ export type OpenAIProviderOptions = {
  * but tools as response to enforce the right JSON schema.
  */
 export const openai = (options: OpenAIProviderOptions): Provider => {
-  const { model, embeddingsModel, options: clientOptions, strictMode = false } = options
+  const { model, options: clientOptions, strictMode = false } = options
   const client = new OpenAI(clientOptions)
 
   return {
@@ -99,13 +95,6 @@ export const openai = (options: OpenAIProviderOptions): Provider => {
           },
         })),
       }
-    },
-    embeddings: async (input: string) => {
-      const response = await client.embeddings.create({
-        model: embeddingsModel,
-        input,
-      })
-      return response.data[0].embedding
     },
   }
 }


### PR DESCRIPTION
It is not supported by many models, and its presence assumes it must be supported for the framework to work. In fact, it is used by single tool at the moment and its better for this tool to provide its own abstraction.