### PR TITLE
feat: bdd unit tests added for `httpTool` example

### DIFF
--- a/example/src/fabrice_latest_issues.config.ts
+++ b/example/src/fabrice_latest_issues.config.ts
@@ -1,0 +1,40 @@
+import 'dotenv/config'
+
+import { httpTool } from '@fabrice-ai/tools/http'
+import { agent } from 'fabrice-ai/agent'
+import { logger } from 'fabrice-ai/telemetry'
+import { workflow } from 'fabrice-ai/workflow'
+
+const browser = agent({
+  description: `
+    You are skilled at browsing Web with specified URLs, 
+    methods, params etc.
+    You are using "httpTool" to get the data from the API and/or Web pages.
+  `,
+  tools: {
+    httpTool,
+  },
+})
+
+const wrapupRedactor = agent({
+  description: `
+    Your role is to check Github project details and check for latest issues.
+  `,
+})
+
+export const checkupGithubProject = workflow({
+  team: { browser, wrapupRedactor },
+  description: `
+    Check the project details for "fabrice-ai" using the following API URL:
+    "https://api.github.com/repos/callstackincubator/fabrice-ai".
+
+    From the data received get the number of stars and the URL for the listing the issues.
+    List last top 3 issues and the number of star gazers for the project.
+  `,
+  output: `
+    Comprehensive markdown report for fabrice-ai project:
+    - Include top 3 new issues.
+    - Include the actual number of star gazers.
+  `,
+  snapshot: logger,
+})

--- a/example/src/fabrice_latest_issues.test.ts
+++ b/example/src/fabrice_latest_issues.test.ts
@@ -1,0 +1,27 @@
+import 'dotenv/config'
+
+import { suite, test } from '@fabrice-ai/bdd/suite'
+import { testwork } from '@fabrice-ai/bdd/testwork'
+
+import { checkupGithubProject } from './fabrice_latest_issues.config.js'
+
+const testResults = await testwork(
+  checkupGithubProject,
+  suite({
+    description: 'Black box testing suite',
+    team: {
+    },
+    workflow: [
+      test('0_check_stars', 'Final report should include the overal number of star gazers'),
+      test('1_check_issues', 'The report should contain list of 3 issues from Fabrice Github project'),      test('3_details', 'Should generate the report with the details of the selected project'),
+    ],
+  })
+)
+
+if (!testResults.passed) {
+  console.log('🚨 Test suite failed')
+  process.exit(-1)
+} else {
+  console.log('✅ Test suite passed')
+  process.exit(0)
+}

--- a/example/src/fabrice_latest_issues.ts
+++ b/example/src/fabrice_latest_issues.ts
@@ -1,45 +1,8 @@
 import 'dotenv/config'
 
-import { httpTool } from '@fabrice-ai/tools/http'
-import { agent } from 'fabrice-ai/agent'
 import { solution } from 'fabrice-ai/solution'
 import { teamwork } from 'fabrice-ai/teamwork'
-import { logger } from 'fabrice-ai/telemetry'
-import { workflow } from 'fabrice-ai/workflow'
-
-const browser = agent({
-  description: `
-    You are skilled at browsing Web with specified URLs, 
-    methods, params etc.
-    You are using "httpTool" to get the data from the API and/or Web pages.
-  `,
-  tools: {
-    httpTool,
-  },
-})
-
-const wrapupRedactor = agent({
-  description: `
-    Your role is to check Github project details and check for latest issues.
-  `,
-})
-
-const checkupGithubProject = workflow({
-  team: { browser, wrapupRedactor },
-  description: `
-    Check the project details for "fabrice-ai" using the following API URL:
-    "https://api.github.com/repos/callstackincubator/fabrice-ai".
-
-    From the data received get the number of stars and the URL for the listing the issues.
-    List last top 3 issues and the number of star gazers for the project.
-  `,
-  output: `
-    Comprehensive markdown report for fabrice-ai project:
-    - Include top 3 new issues.
-    - Include the actual number of star gazers.
-  `,
-  snapshot: logger,
-})
+import { checkupGithubProject } from './fabrice_latest_issues.config'
 
 const result = await teamwork(checkupGithubProject)
 


### PR DESCRIPTION
Missing unit tests for the `fabrice_latest_issues.ts` example added